### PR TITLE
Format patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For example, to use seo friendly titles, your layout.rhtml should be looking lik
 
     require 'karakuri'
 
-    Karakuri.title_separator = '+'
+    Karakuri.title_separator '+'
 
 
 ### Tags
@@ -77,7 +77,7 @@ Next, you need a place to show the tag links, for example the index.rhtml:
 
     require 'karakuri'
 
-    Karakuri.link_format = '<a href="/tagged?tag={tag}" title="your customed title">{tag}</a> '
+    Karakuri.link_format '<a href="/tagged?tag={tag}" title="your customed title">{tag}</a> '
 
 `{tag}` (keep it as it is in your `config.ru`) will be the placeholder for your tag corresponding to each article and is required.
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ For example, to use seo friendly titles, your layout.rhtml should be looking lik
     .
     .
 
+**TIPS**: To have a customized title separator, put this in your `config.ru`
+
+    require 'karakuri'
+
+    Karakuri.title_separator = '+'
+
+
 ### Tags
 Adding the tagging feature requires the _toto_prerelease_ as mentioned above, since we need the http request to apply our little hack.
 
@@ -66,9 +73,16 @@ Next, you need a place to show the tag links, for example the index.rhtml:
     .
     .
 
+**TIPS**: Again, to customize your tag link format, put this in your `config.ru`:
+
+    require 'karakuri'
+
+    Karakuri.link_format = '<a href="/tagged?tag={tag}" title="your customed title">{tag}</a> '
+
+`{tag}` (keep it as it is in your `config.ru`) will be the placeholder for your tag corresponding to each article and is required.
 
 
-And again: piece of cake ;-). Now all we need to add is a page that displays articles belonging to a ceratin tag:
+And again: piece of cake ;-). Now all we need to add is a page that displays articles belonging to a certain tag:
 
 Create a page called `tagged.rhtml` in your `templates/pages` directory that looks like this:
 
@@ -82,7 +96,7 @@ Create a page called `tagged.rhtml` in your `templates/pages` directory that loo
 
     <% Karakuri::desired_articles(@articles, desired_tag).each do |article| %>
       <li>
-        <span class="descr"><a href="<%= article.path %>" alt="<%= article.title %>"><%= article.title %></a><br/></span>
+        <span class="descr"><a href="<%= article.path %>" title="<%= article.title %>"><%= article.title %></a><br/></span>
       </li>
     <% end %>
     </ul>
@@ -96,14 +110,14 @@ Example usage:
 
     <h1>Tags</h1>
     <%  Karakuri::tag_cloud(@articles).each do |tag, freq| %>
-        <%= %|<a href="/tagged?tag=#{tag}" alt="articles concerning #{tag}" style="font-size: #{10 * freq}px">#{tag}</a>| %>
+        <%= %|<a href="/tagged?tag=#{tag}" title="articles concerning #{tag}" style="font-size: #{10 * freq}px">#{tag}</a>| %>
     <% end %>
     
 Thanks [baopham](https://github.com/baopham) for the nice addition.
 
 ### short url (via bit.ly)
 
-To use a bit.ly shortened URL, just call the followin function inside a .rhtml file:
+To use a bit.ly shortened URL, just call the following function inside a .rhtml file:
 
     <%= Karakuri::short_url_bitly(<url>, <bit.ly login name>, <bit.ly api key>) %>
 

--- a/lib/karakuri.rb
+++ b/lib/karakuri.rb
@@ -6,16 +6,25 @@ require 'uri'
 # Some useful feature for toto and the likes. Basically, any ruby based blog or site.
 #
 module Karakuri
+  @link_format = '<a href="/tagged?tag={tag}" title="articles concerning {tag}">{tag}</a> '
+  @title_separator = '|'
+
+  def self.link_format(format)
+    @link_format = format
+  end
+
+  def self.title_separator(separator)
+    @title_separator = separator
+  end
   #
-  # create a list of links to tagged articles, default link_format: <code>%&amp;&lt;a href=&quot;/tagged?tag=#{tag}&quot; alt=&quot;articles concerning #{tag}&quot; &gt;#{tag}&lt;/a&gt; &amp;</code>
+  # create a list of links to tagged articles, default link_format: <code>%&amp;&lt;a href=&quot;/tagged?tag=#{tag}&quot; title=&quot;articles concerning #{tag}&quot;&gt;#{tag}&lt;/a&gt; &amp;</code>
   #
   def Karakuri.tag_link_list(csv_string)
     # read csv-string into array
     tag_list = csv_to_array(csv_string)
     if tag_list
       tag_string = ""
-      #TODO pass a format via parameter
-      tag_list.each { |tag| tag_string << %&<a href="/tagged?tag=#{tag}" alt="articles concerning #{tag}" >#{tag}</a> & }
+      tag_list.each { |tag| tag_string << @link_format.gsub('{tag}', tag) }
     end
     tag_string
   end
@@ -31,13 +40,12 @@ module Karakuri
   # example for toto: <code>seo_friendly_title(@path, title, "mysite.com") will produce 'subpage | mysite.com' as seo friendly page title.</code>
   #
   def Karakuri.seo_friendly_title(path, title, seo_ending)
-    #TODO use custom title separator...
        if path == 'index'
         page_title = seo_ending
        elsif path.split('/').compact.length == 4
-        page_title = title << " | #{seo_ending}"
+        page_title = title << " #{@title_separator} #{seo_ending}"
        else
-        page_title = path.capitalize.gsub(/[-]/, ' ') << " | #{seo_ending}"
+        page_title = path.capitalize.gsub(/[-]/, ' ') << " #{@title_separator} #{seo_ending}"
       end
       page_title
   end

--- a/test/karakuri_test.rb
+++ b/test/karakuri_test.rb
@@ -44,13 +44,13 @@ class KarakuriTest < Test::Unit::TestCase
     result_01 = Karakuri::tag_link_list(STRING_01)
     assert("Unexpected mapping for #{STRING_01}!", result_01 == "<a href=/tagged?tag=tag_1 >tag_1</a> ")
     result_02 = Karakuri::tag_link_list(STRING_02)
-    expected_result_02 = %{<a href="/tagged?tag=tag_1" alt="articles concerning tag_1" >tag_1</a> <a href="/tagged?tag=tag_2" alt="articles concerning tag_2" >tag_2</a> }
+    expected_result_02 = %{<a href="/tagged?tag=tag_1" title="articles concerning tag_1">tag_1</a> <a href="/tagged?tag=tag_2" title="articles concerning tag_2">tag_2</a> }
     assert(result_02 == expected_result_02, "Unexpected mapping for #{STRING_02}!")
     result_03 = Karakuri::tag_link_list(STRING_03)
-    expected_result_03 = %{<a href="/tagged?tag=tag_1" alt="articles concerning tag_1" >tag_1</a> <a href="/tagged?tag=tag_2" alt="articles concerning tag_2" >tag_2</a> <a href="/tagged?tag=tag_3" alt="articles concerning tag_3" >tag_3</a> }
+    expected_result_03 = %{<a href="/tagged?tag=tag_1" title="articles concerning tag_1">tag_1</a> <a href="/tagged?tag=tag_2" title="articles concerning tag_2">tag_2</a> <a href="/tagged?tag=tag_3" title="articles concerning tag_3">tag_3</a> }
     assert(result_03 == expected_result_03, "Unexpected mapping for #{STRING_03}!")
     result_04 = Karakuri::tag_link_list(STRING_04)
-    expected_result_04 = %{<a href="/tagged?tag=hacks" alt="articles concerning hacks" >hacks</a> <a href="/tagged?tag=love" alt="articles concerning love" >love</a> <a href="/tagged?tag=rock 'n' roll" alt="articles concerning rock 'n' roll" >rock 'n' roll</a> }
+    expected_result_04 = %{<a href="/tagged?tag=hacks" title="articles concerning hacks">hacks</a> <a href="/tagged?tag=love" title="articles concerning love">love</a> <a href="/tagged?tag=rock 'n' roll" title="articles concerning rock 'n' roll">rock 'n' roll</a> }
     assert(result_04 == expected_result_04, "Unexpected mapping for #{STRING_04}!")
   end
   def test_short_url_bitly
@@ -204,6 +204,9 @@ class KarakuriTest < Test::Unit::TestCase
     result_02 = Karakuri::tag_link_list(article_02_mock[:tags])
     expected_02 =  '<a href="/tag_1">tag_1</a><a href="/tag_2">tag_2</a>'
     assert(result_02 == expected_02, "Link for tag is wrong, expected #{expected_02}, was #{result_02}")
+
+    # Reset to default for other tests
+    Karakuri.link_format '<a href="/tagged?tag={tag}" title="articles concerning {tag}">{tag}</a> '
   end
 
   def test_title_separator
@@ -220,6 +223,9 @@ class KarakuriTest < Test::Unit::TestCase
     result = Karakuri::seo_friendly_title(path, 'test', 'Karakuri')
     expected = "Example + Karakuri"
     assert(result == expected, "Page title is wrong, expected #{expected}, was #{result}")
+
+    # Reset to default for other tests
+    Karakuri.title_separator '|'
   end
 
 end

--- a/test/karakuri_test.rb
+++ b/test/karakuri_test.rb
@@ -176,5 +176,51 @@ class KarakuriTest < Test::Unit::TestCase
 
   end
 
+  def test_link_format
+    #mock articles
+    article_01_mock = Hash.new()
+    article_02_mock = Hash.new()
+
+    article_01_mock[:tags] = STRING_01
+
+    article_02_mock[:tags] = STRING_02
+
+    # Test the default link format
+    result_01 = Karakuri::tag_link_list(article_01_mock[:tags])
+    expected_01 = "<a href=\"/tagged?tag=#{STRING_01}\" title=\"articles concerning #{STRING_01}\">#{STRING_01}</a> "
+    assert(result_01 == expected_01 , "Link for tag is wrong, expected #{expected_01}, was #{result_01}")
+
+    result_02 = Karakuri::tag_link_list(article_02_mock[:tags])
+    expected_02 =  '<a href="/tagged?tag=tag_1" title="articles concerning tag_1">tag_1</a> <a href="/tagged?tag=tag_2" title="articles concerning tag_2">tag_2</a> '
+    assert(result_02 == expected_02, "Link for tag is wrong, expected #{expected_02}, was #{result_02}")
+
+    # Test customed link format
+    Karakuri.link_format '<a href="/{tag}">{tag}</a>'
+
+    result_01 = Karakuri::tag_link_list(article_01_mock[:tags])
+    expected_01 = "<a href=\"/#{STRING_01}\">#{STRING_01}</a>"
+    assert(result_01 == expected_01 , "Link for tag is wrong, expected #{expected_01}, was #{result_01}")
+
+    result_02 = Karakuri::tag_link_list(article_02_mock[:tags])
+    expected_02 =  '<a href="/tag_1">tag_1</a><a href="/tag_2">tag_2</a>'
+    assert(result_02 == expected_02, "Link for tag is wrong, expected #{expected_02}, was #{result_02}")
+  end
+
+  def test_title_separator
+    # Test the default title separator '|'
+    path = 'example'
+    title = 'test'
+    seo_ending = 'Karakuri'
+    result = Karakuri::seo_friendly_title(path, title, seo_ending)
+    expected = "Example | Karakuri"
+    assert(result == expected, "Page title is wrong, expected #{expected}, was #{result}")
+
+    # Test customed title separator '+'
+    Karakuri.title_separator '+'
+    result = Karakuri::seo_friendly_title(path, 'test', 'Karakuri')
+    expected = "Example + Karakuri"
+    assert(result == expected, "Page title is wrong, expected #{expected}, was #{result}")
+  end
+
 end
 


### PR DESCRIPTION
This pull request #5 is not so helpful so I tried to finish some of the TODO's. 

It will allow users to customize their tag link format and title separator

``` ruby
require 'karakuri'

Karakuri.link_format '<a href="/tagged?tag={tag}" title="whatever here">{tag}</a> ' 
Karakuri.title_separator '+'
```

`{tag}` will then be replaced in the function tag_link_list with the appropriate tag of each article
